### PR TITLE
[FEATURE] add index for tt_content::tx_news_related_news

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -271,6 +271,7 @@ CREATE TABLE be_users (
 #
 CREATE TABLE tt_content (
 	tx_news_related_news int(11) DEFAULT '0' NOT NULL,
+	KEY index_newscontent (tx_news_related_news)
 );
 
 #


### PR DESCRIPTION
we experienced quite some load on the mysql-Server with queries fetching the related content for news.
We have > 100.000 entries in tt_content.
Also for smaller sites i see no harm in having such an index.

EXT:news rocks! Keep going!
